### PR TITLE
feat: add -m, -n, -f, -c options

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ Options:
   -x, --exclusive  Exclude production dependencies       [boolean]
   -s, --sort       Sort list before printing             [boolean]
   -v, --versions   Lookup installed and latest versions  [boolean]
-  -t, --terse      Print names only, without color       [boolean]
+  -m, --major      Only deps behind by major version     [boolean]
+  -n, --minor      Only deps behind by minor version     [boolean]
+  -f, --patch      Only deps behind by patch version     [boolean]
+  -c, --command    Print commands to update to latest    [boolean]
+  -t, --terse      Print names/commands only, no color   [boolean]
   -h, --help       Print this help content               [boolean]
   -V, --version    Print cies program version            [boolean]
 ```

--- a/cli.js
+++ b/cli.js
@@ -12,7 +12,7 @@ const colors = {
 
 let opts, spinner
 const cli = require('sywac')
-  .preface(null, 'List dependencies from package.json')
+  .preface(null, chalk.white.underline('List dependencies from package.json'))
   .positional('[dir]', {
     paramsDesc: 'Optional path to directory containing package.json'
   })
@@ -52,6 +52,16 @@ const cli = require('sywac')
     implicitCommand: false
   })
   .outputSettings({ maxWidth: 66 })
+  .style({
+    usagePrefix: str => {
+      return chalk.white(str.slice(0, 6)) + ' ' + chalk.magenta(str.slice(7))
+    },
+    usagePositionals: str => chalk.green(str),
+    usageOptionsPlaceholder: str => chalk.cyan(str),
+    group: s => chalk.white(s),
+    flags: s => s[0] === '[' ? chalk.green(s) : chalk.cyan(s),
+    hints: s => chalk.dim(s)
+  })
 
 module.exports = function run () {
   return cli

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 'use strict'
 
-const chalk = require('chalk')
+const cliStyle = require('sywac-style-basic')
+const chalk = cliStyle.chalk
 const colors = {
   prod: 'cyan',
   dev: 'magenta',
@@ -40,8 +41,20 @@ const cli = require('sywac')
   .boolean('-v, --versions', {
     desc: 'Lookup installed and latest versions'
   })
+  .boolean('-m, --major', {
+    desc: 'Only deps behind by major version'
+  })
+  .boolean('-n, --minor', {
+    desc: 'Only deps behind by minor version'
+  })
+  .boolean('-f, --patch', {
+    desc: 'Only deps behind by patch version'
+  })
+  .boolean('-c, --command', {
+    desc: 'Print commands to update to latest'
+  })
   .boolean('-t, --terse', {
-    desc: 'Print names only, without color'
+    desc: 'Print names/commands only, no color'
   })
   .help('-h, --help', {
     desc: 'Print this help content',
@@ -52,22 +65,14 @@ const cli = require('sywac')
     implicitCommand: false
   })
   .outputSettings({ maxWidth: 66 })
-  .style({
-    usagePrefix: str => {
-      return chalk.white(str.slice(0, 6)) + ' ' + chalk.magenta(str.slice(7))
-    },
-    usagePositionals: str => chalk.green(str),
-    usageOptionsPlaceholder: str => chalk.cyan(str),
-    group: s => chalk.white(s),
-    flags: s => s[0] === '[' ? chalk.green(s) : chalk.cyan(s),
-    hints: s => chalk.dim(s)
-  })
+  .style(cliStyle)
 
 module.exports = function run () {
   return cli
     .parseAndExit()
     .then(argv => {
       opts = argv
+      if (opts.command) opts.versions = true // have to check versions in order to determine command
       if (!opts.terse && opts.versions) {
         spinner = require('ora')({ text: chalk.white('Loading versions'), color: 'green', spinner: 'arrow3' }).start()
       }
@@ -80,7 +85,7 @@ module.exports = function run () {
       let versLen = 0
       let lateLen = 0
       deps.forEach(d => {
-        if (opts.terse) return console.log(d.name)
+        if (opts.terse && !opts.command) return console.log(d.name)
         nameLen = Math.max(nameLen, d.name.length)
         d.typeString = d.types.join(',')
         typeLen = Math.max(typeLen, d.typeString.length)
@@ -88,7 +93,6 @@ module.exports = function run () {
         if (d.version) versLen = Math.max(versLen, d.version.length)
         if (d.latest) lateLen = Math.max(lateLen, d.latest.length)
       })
-      if (opts.terse) return
 
       const dcolorMap = new Map([
         [/pre/, 'white'],
@@ -107,22 +111,63 @@ module.exports = function run () {
         return noop
       }
 
-      let name, type, semv, versions, diffColor
+      let sv
+      function semver () {
+        if (!sv) sv = require('semver')
+        return sv
+      }
+
+      let name, type, semv, versions, diffColor, needsUpdate, updateFlags
       deps.forEach(d => {
-        name = chalk.white(d.name) + new Array(nameLen - d.name.length + 2).join(' ')
-        type = d.types.map(type => chalk[colors[type]](type)).join(',') + new Array(typeLen - d.typeString.length + 2).join(' ')
-        semv = d.semver
+        if (!opts.terse) {
+          name = chalk.white(d.name) + new Array(nameLen - d.name.length + 2).join(' ')
+          type = d.types.map(type => chalk[colors[type]](type)).join(',') + new Array(typeLen - d.typeString.length + 2).join(' ')
+          semv = d.semver
+        }
         if (d.version) {
           versions = new Array(semvLen - d.semver.length + 2).join(' ') + chalk.inverse(d.version)
           diffColor = dcolor(d.diff)
           versions += new Array(versLen - d.version.length + 2).join(' ') + diffColor(d.latest)
-          if (d.diff) versions += new Array(lateLen - d.latest.length + 2).join(' ') + diffColor(d.diff)
+          if (d.diff) {
+            versions += new Array(lateLen - d.latest.length + 2).join(' ') + diffColor(d.diff)
+            if (opts.command && d.diff !== 'in-range') {
+              updateFlags = d.types.map(type => {
+                switch (type) {
+                  case 'prod':
+                    return 'P'
+                  case 'dev':
+                    return 'D'
+                  case 'optional':
+                    return 'O'
+                  case 'bundled':
+                    return 'B'
+                }
+                return null
+              }).filter(Boolean)
+              if (updateFlags.length && semver().validRange(d.semver) === d.semver) updateFlags.push('E')
+              if (updateFlags.length) {
+                updateFlags = updateFlags.sort().join('')
+                if (!needsUpdate) needsUpdate = {}
+                // needsUpdate[updateFlags] = (needsUpdate[updateFlags] || []).concat(d.name + '@latest')
+                needsUpdate[updateFlags] = (needsUpdate[updateFlags] || []).concat(d.name + (d.latest === 'no latest' ? '' : '@' + d.latest))
+              }
+            }
+          }
         } else {
           versions = ''
         }
         if (spinner) spinner.stop()
-        console.log(name + type + semv + versions)
+        if (!opts.terse) console.log(name + type + semv + versions)
       })
+      if (opts.command) {
+        if (!opts.terse) console.log() // empty line
+        if (!needsUpdate) console.log('Nothing to update :)')
+        else {
+          for (let [flags, pkgs] of Object.entries(needsUpdate)) {
+            console.log(`npm i -${flags} ` + pkgs.join(' '))
+          }
+        }
+      }
     })
     .catch(err => {
       if (spinner) spinner.stop()

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = function cies (opts) {
     if (opts.sort) deps.sort((a, b) => a.name.localeCompare(b.name))
     return deps
   }).then(deps => {
-    if (opts.terse || !opts.versions) return deps
+    if ((!opts.versions || (opts.terse && !opts.command)) && !opts.major && !opts.minor && !opts.patch) return deps
 
     const promises = []
     let scopeName
@@ -80,6 +80,13 @@ module.exports = function cies (opts) {
         } else {
           deps[i].diff = '¯\\_(ツ)_/¯'
         }
+      }
+      if (opts.major || opts.minor || opts.patch) {
+        let matches = [/out/, /ツ/]
+        if (opts.major) matches.push(/major/)
+        if (opts.minor) matches.push(/minor/)
+        if (opts.patch) matches.push(/patch/)
+        return deps.filter(d => matches.some(regex => regex.test(d.diff)))
       }
       return deps
     })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "bundled",
     "optionalDependencies",
     "optional",
-    "cli"
+    "cli",
+    "latest",
+    "version",
+    "versions"
   ],
   "author": "nexdrew",
   "license": "ISC",
@@ -45,10 +48,10 @@
     "tap": "^12.0.1"
   },
   "dependencies": {
-    "chalk": "^2.3.2",
     "latest-version": "^4.0.0",
     "ora": "^3.0.0",
     "semver": "^5.5.0",
-    "sywac": "^1.2.0"
+    "sywac": "^1.2.0",
+    "sywac-style-basic": "^1.0.0"
   }
 }

--- a/test/all/package.json
+++ b/test/all/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@nexdrew/slugid": "^2.0.0",
     "cliui": "^3.2.0",
-    "decamelize": "^1.1.1",
+    "decamelize": "1.1.1",
     "find-up": "^2.1.0"
   },
   "devDependencies": {

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -191,3 +191,29 @@ test('supports alt bundleDependencies', t => {
     t.notOk(r.stderr)
   })
 })
+
+test('-h prints help text', t => {
+  return cli('-h').then(r => {
+    t.equal(r.stdout, withLineFeeds([
+      chalk.white.underline('List dependencies from package.json'),
+      '',
+      chalk`{white Usage:} {magenta cli} {green [dir]} {cyan [options]}`,
+      '',
+      chalk.white('Arguments:'),
+      chalk`  {green [dir]}  Optional path to directory containing package.json  {dim [dir]}`,
+      '',
+      chalk.white('Options:'),
+      chalk`  {cyan -d, --dev}        Include devDependencies               {dim [boolean]}`,
+      chalk`  {cyan -p, --peer}       Include peerDependencies              {dim [boolean]}`,
+      chalk`  {cyan -b, --bundled}    Include bundledDependencies           {dim [boolean]}`,
+      chalk`  {cyan -o, --optional}   Include optionalDependencies          {dim [boolean]}`,
+      chalk`  {cyan -a, --all}        Include dependencies from all types   {dim [boolean]}`,
+      chalk`  {cyan -x, --exclusive}  Exclude production dependencies       {dim [boolean]}`,
+      chalk`  {cyan -s, --sort}       Sort list before printing             {dim [boolean]}`,
+      chalk`  {cyan -v, --versions}   Lookup installed and latest versions  {dim [boolean]}`,
+      chalk`  {cyan -t, --terse}      Print names only, without color       {dim [boolean]}`,
+      chalk`  {cyan -h, --help}       Print this help content               {dim [boolean]}`,
+      chalk`  {cyan -V, --version}    Print cies program version            {dim [boolean]}`
+    ]))
+  })
+})

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -5,7 +5,7 @@ process.env.FORCE_COLOR = '1'
 const test = require('tap').test
 const cp = require('child_process')
 const path = require('path')
-const chalk = require('chalk')
+const chalk = require('sywac-style-basic').chalk
 const pkg = require('../package.json')
 
 const parentPath = path.resolve(__dirname, '..')
@@ -31,11 +31,11 @@ function withLineFeeds (array) {
 test('default includes dependencies', t => {
   return cli().then(r => {
     t.equal(r.stdout, withLineFeeds([
-      chalk`{white chalk}          {cyan prod} ${pkg.dependencies.chalk}`,
-      chalk`{white latest-version} {cyan prod} ${pkg.dependencies['latest-version']}`,
-      chalk`{white ora}            {cyan prod} ${pkg.dependencies.ora}`,
-      chalk`{white semver}         {cyan prod} ${pkg.dependencies.semver}`,
-      chalk`{white sywac}          {cyan prod} ${pkg.dependencies.sywac}`
+      chalk`{white latest-version}    {cyan prod} ${pkg.dependencies['latest-version']}`,
+      chalk`{white ora}               {cyan prod} ${pkg.dependencies.ora}`,
+      chalk`{white semver}            {cyan prod} ${pkg.dependencies.semver}`,
+      chalk`{white sywac}             {cyan prod} ${pkg.dependencies.sywac}`,
+      chalk`{white sywac-style-basic} {cyan prod} ${pkg.dependencies['sywac-style-basic']}`
     ]))
     t.notOk(r.stderr)
   })
@@ -44,16 +44,16 @@ test('default includes dependencies', t => {
 test('--dev includes dependencies and devDependencies', t => {
   return cli(`${parentPath} --dev`).then(r => {
     t.equal(r.stdout, withLineFeeds([
-      chalk`{white chalk}            {cyan prod} ${pkg.dependencies.chalk}`,
-      chalk`{white latest-version}   {cyan prod} ${pkg.dependencies['latest-version']}`,
-      chalk`{white ora}              {cyan prod} ${pkg.dependencies.ora}`,
-      chalk`{white semver}           {cyan prod} ${pkg.dependencies.semver}`,
-      chalk`{white sywac}            {cyan prod} ${pkg.dependencies.sywac}`,
-      chalk`{white coveralls}        {magenta dev}  ${pkg.devDependencies.coveralls}`,
-      chalk`{white mockery}          {magenta dev}  ${pkg.devDependencies.mockery}`,
-      chalk`{white standard}         {magenta dev}  ${pkg.devDependencies.standard}`,
-      chalk`{white standard-version} {magenta dev}  ${pkg.devDependencies['standard-version']}`,
-      chalk`{white tap}              {magenta dev}  ${pkg.devDependencies.tap}`
+      chalk`{white latest-version}    {cyan prod} ${pkg.dependencies['latest-version']}`,
+      chalk`{white ora}               {cyan prod} ${pkg.dependencies.ora}`,
+      chalk`{white semver}            {cyan prod} ${pkg.dependencies.semver}`,
+      chalk`{white sywac}             {cyan prod} ${pkg.dependencies.sywac}`,
+      chalk`{white sywac-style-basic} {cyan prod} ${pkg.dependencies['sywac-style-basic']}`,
+      chalk`{white coveralls}         {magenta dev}  ${pkg.devDependencies.coveralls}`,
+      chalk`{white mockery}           {magenta dev}  ${pkg.devDependencies.mockery}`,
+      chalk`{white standard}          {magenta dev}  ${pkg.devDependencies.standard}`,
+      chalk`{white standard-version}  {magenta dev}  ${pkg.devDependencies['standard-version']}`,
+      chalk`{white tap}               {magenta dev}  ${pkg.devDependencies.tap}`
     ]))
     t.notOk(r.stderr)
   })
@@ -62,16 +62,16 @@ test('--dev includes dependencies and devDependencies', t => {
 test('--all includes everything defined', t => {
   return cli(`${parentPath} --all`).then(r => {
     t.equal(r.stdout, withLineFeeds([
-      chalk`{white chalk}            {cyan prod} ${pkg.dependencies.chalk}`,
-      chalk`{white latest-version}   {cyan prod} ${pkg.dependencies['latest-version']}`,
-      chalk`{white ora}              {cyan prod} ${pkg.dependencies.ora}`,
-      chalk`{white semver}           {cyan prod} ${pkg.dependencies.semver}`,
-      chalk`{white sywac}            {cyan prod} ${pkg.dependencies.sywac}`,
-      chalk`{white coveralls}        {magenta dev}  ${pkg.devDependencies.coveralls}`,
-      chalk`{white mockery}          {magenta dev}  ${pkg.devDependencies.mockery}`,
-      chalk`{white standard}         {magenta dev}  ${pkg.devDependencies.standard}`,
-      chalk`{white standard-version} {magenta dev}  ${pkg.devDependencies['standard-version']}`,
-      chalk`{white tap}              {magenta dev}  ${pkg.devDependencies.tap}`
+      chalk`{white latest-version}    {cyan prod} ${pkg.dependencies['latest-version']}`,
+      chalk`{white ora}               {cyan prod} ${pkg.dependencies.ora}`,
+      chalk`{white semver}            {cyan prod} ${pkg.dependencies.semver}`,
+      chalk`{white sywac}             {cyan prod} ${pkg.dependencies.sywac}`,
+      chalk`{white sywac-style-basic} {cyan prod} ${pkg.dependencies['sywac-style-basic']}`,
+      chalk`{white coveralls}         {magenta dev}  ${pkg.devDependencies.coveralls}`,
+      chalk`{white mockery}           {magenta dev}  ${pkg.devDependencies.mockery}`,
+      chalk`{white standard}          {magenta dev}  ${pkg.devDependencies.standard}`,
+      chalk`{white standard-version}  {magenta dev}  ${pkg.devDependencies['standard-version']}`,
+      chalk`{white tap}               {magenta dev}  ${pkg.devDependencies.tap}`
     ]))
     t.notOk(r.stderr)
   })
@@ -80,16 +80,16 @@ test('--all includes everything defined', t => {
 test('--sort sorts list', t => {
   return cli(`${parentPath} --all --sort`).then(r => {
     t.equal(r.stdout, withLineFeeds([
-      chalk`{white chalk}            {cyan prod} ${pkg.dependencies.chalk}`,
-      chalk`{white coveralls}        {magenta dev}  ${pkg.devDependencies.coveralls}`,
-      chalk`{white latest-version}   {cyan prod} ${pkg.dependencies['latest-version']}`,
-      chalk`{white mockery}          {magenta dev}  ${pkg.devDependencies.mockery}`,
-      chalk`{white ora}              {cyan prod} ${pkg.dependencies.ora}`,
-      chalk`{white semver}           {cyan prod} ${pkg.dependencies.semver}`,
-      chalk`{white standard}         {magenta dev}  ${pkg.devDependencies.standard}`,
-      chalk`{white standard-version} {magenta dev}  ${pkg.devDependencies['standard-version']}`,
-      chalk`{white sywac}            {cyan prod} ${pkg.dependencies.sywac}`,
-      chalk`{white tap}              {magenta dev}  ${pkg.devDependencies.tap}`
+      chalk`{white coveralls}         {magenta dev}  ${pkg.devDependencies.coveralls}`,
+      chalk`{white latest-version}    {cyan prod} ${pkg.dependencies['latest-version']}`,
+      chalk`{white mockery}           {magenta dev}  ${pkg.devDependencies.mockery}`,
+      chalk`{white ora}               {cyan prod} ${pkg.dependencies.ora}`,
+      chalk`{white semver}            {cyan prod} ${pkg.dependencies.semver}`,
+      chalk`{white standard}          {magenta dev}  ${pkg.devDependencies.standard}`,
+      chalk`{white standard-version}  {magenta dev}  ${pkg.devDependencies['standard-version']}`,
+      chalk`{white sywac}             {cyan prod} ${pkg.dependencies.sywac}`,
+      chalk`{white sywac-style-basic} {cyan prod} ${pkg.dependencies['sywac-style-basic']}`,
+      chalk`{white tap}               {magenta dev}  ${pkg.devDependencies.tap}`
     ]))
     t.notOk(r.stderr)
   })
@@ -97,7 +97,7 @@ test('--sort sorts list', t => {
 
 test('--terse prints uncolored names only', t => {
   return cli(`${parentPath} --all --terse`).then(r => {
-    t.equal(r.stdout, withLineFeeds(['chalk', 'latest-version', 'ora', 'semver', 'sywac', 'coveralls', 'mockery', 'standard', 'standard-version', 'tap']))
+    t.equal(r.stdout, withLineFeeds(['latest-version', 'ora', 'semver', 'sywac', 'sywac-style-basic', 'coveralls', 'mockery', 'standard', 'standard-version', 'tap']))
     t.notOk(r.stderr)
   })
 })
@@ -143,7 +143,7 @@ test('supports all dependency types', t => {
       chalk`{white chai}                {magenta dev}          ^3.4.1`,
       chalk`{white chalk}               {magenta dev}          ^1.1.3`,
       chalk`{white cliui}               {cyan prod},{green bundled} ^3.2.0`,
-      chalk`{white decamelize}          {cyan prod}         ^1.1.1`,
+      chalk`{white decamelize}          {cyan prod}         1.1.1`,
       chalk`{white dezalgo}             {green bundled}      unknown`,
       chalk`{white find-up}             {cyan prod},{magenta dev}     ^2.1.0`,
       chalk`{white fs-vacuum}           {green bundled}      unknown`,
@@ -165,7 +165,7 @@ test('-v looks up installed versions', t => {
       chalk`{white chai}                {magenta dev}          ^3.4.1  {inverse not installed} {magenta 3.5.0}     {magenta in-range}`,
       chalk`{white chalk}               {magenta dev}          ^1.1.3  {inverse not installed} {cyan 9.9.9}     {cyan out-of-range}`,
       chalk`{white cliui}               {cyan prod},{green bundled} ^3.2.0  {inverse 3.3.0}         {yellow 3.4.0}     {yellow minor}`,
-      chalk`{white decamelize}          {cyan prod}         ^1.1.1  {inverse 1.1.1}         {red 9.9.9}     {red major}`,
+      chalk`{white decamelize}          {cyan prod}         1.1.1   {inverse 1.1.1}         {red 9.9.9}     {red major}`,
       chalk`{white dezalgo}             {green bundled}      unknown {inverse not installed} 9.9.9     ¯\\_(ツ)_/¯`,
       chalk`{white find-up}             {cyan prod},{magenta dev}     ^2.1.0  {inverse 2.1.0}         {green 2.1.0}`,
       chalk`{white fs-vacuum}           {green bundled}      unknown {inverse not installed} no latest ¯\\_(ツ)_/¯`,
@@ -180,6 +180,65 @@ test('-v looks up installed versions', t => {
   })
 })
 
+test('-m filters to deps requiring major bump', t => {
+  return cli(`${path.resolve(__dirname, 'all')} -m`, true).then(r => {
+    t.equal(r.stdout, withLineFeeds([
+      chalk`{white decamelize} {cyan prod} 1.1.1 {inverse 1.1.1} {red 9.9.9} {red major}`
+    ]))
+  })
+})
+
+test('-n filters to deps requiring minor bump', t => {
+  return cli(`${path.resolve(__dirname, 'all')} -n`, true).then(r => {
+    t.equal(r.stdout, withLineFeeds([
+      chalk`{white cliui} {cyan prod} ^3.2.0 {inverse 3.3.0} {yellow 3.4.0} {yellow minor}`
+    ]))
+  })
+})
+
+test('-f filters to deps requiring patch bump', t => {
+  return cli(`${path.resolve(__dirname, 'all')} -f`, true).then(r => {
+    t.equal(r.stdout, withLineFeeds([
+      chalk`{white @nexdrew/slugid} {cyan prod} ^2.0.0 {inverse 2.0.1} {blue 2.0.2} {blue patch}`
+    ]))
+  })
+})
+
+test('-c includes commands to update deps', t => {
+  return cli(`${path.resolve(__dirname, 'all')} -c`, true).then(r => {
+    t.equal(r.stdout, withLineFeeds([
+      chalk`{white @nexdrew/slugid} {cyan prod} ^2.0.0 {inverse 2.0.1} {blue 2.0.2} {blue patch}`,
+      chalk`{white cliui}           {cyan prod} ^3.2.0 {inverse 3.3.0} {yellow 3.4.0} {yellow minor}`,
+      chalk`{white decamelize}      {cyan prod} 1.1.1  {inverse 1.1.1} {red 9.9.9} {red major}`,
+      chalk`{white find-up}         {cyan prod} ^2.1.0 {inverse 2.1.0} {green 2.1.0}`,
+      '',
+      'npm i -P @nexdrew/slugid@2.0.2 cliui@3.4.0',
+      'npm i -EP decamelize@9.9.9'
+    ]))
+  })
+})
+
+test('-ct includes only commands to update deps', t => {
+  return cli(`${path.resolve(__dirname, 'all')} -cat`, true).then(r => {
+    t.equal(r.stdout, withLineFeeds([
+      'npm i -P @nexdrew/slugid@2.0.2',
+      'npm i -BP cliui@3.4.0',
+      'npm i -EP decamelize@9.9.9',
+      'npm i -D chalk@9.9.9 which@9.9.9',
+      'npm i -B dezalgo@9.9.9 fs-vacuum write-file-atomic@9.9.9',
+      'npm i -O react-router@9.9.9 redux-simple-router@9.9.9'
+    ]))
+  })
+})
+
+test('-c tells you if there\'s nothing to update', t => {
+  return cli(`${path.resolve(__dirname, 'all')} -cptx`, true).then(r => {
+    t.equal(r.stdout, withLineFeeds([
+      'Nothing to update :)'
+    ]))
+  })
+})
+
 test('supports alt bundleDependencies', t => {
   return cli(`${path.resolve(__dirname, 'bundle-alt')} -xb`).then(r => {
     t.equal(r.stdout, withLineFeeds([
@@ -189,31 +248,5 @@ test('supports alt bundleDependencies', t => {
       chalk`{white aproba}     {green bundled} unknown`
     ]))
     t.notOk(r.stderr)
-  })
-})
-
-test('-h prints help text', t => {
-  return cli('-h').then(r => {
-    t.equal(r.stdout, withLineFeeds([
-      chalk.white.underline('List dependencies from package.json'),
-      '',
-      chalk`{white Usage:} {magenta cli} {green [dir]} {cyan [options]}`,
-      '',
-      chalk.white('Arguments:'),
-      chalk`  {green [dir]}  Optional path to directory containing package.json  {dim [dir]}`,
-      '',
-      chalk.white('Options:'),
-      chalk`  {cyan -d, --dev}        Include devDependencies               {dim [boolean]}`,
-      chalk`  {cyan -p, --peer}       Include peerDependencies              {dim [boolean]}`,
-      chalk`  {cyan -b, --bundled}    Include bundledDependencies           {dim [boolean]}`,
-      chalk`  {cyan -o, --optional}   Include optionalDependencies          {dim [boolean]}`,
-      chalk`  {cyan -a, --all}        Include dependencies from all types   {dim [boolean]}`,
-      chalk`  {cyan -x, --exclusive}  Exclude production dependencies       {dim [boolean]}`,
-      chalk`  {cyan -s, --sort}       Sort list before printing             {dim [boolean]}`,
-      chalk`  {cyan -v, --versions}   Lookup installed and latest versions  {dim [boolean]}`,
-      chalk`  {cyan -t, --terse}      Print names only, without color       {dim [boolean]}`,
-      chalk`  {cyan -h, --help}       Print this help content               {dim [boolean]}`,
-      chalk`  {cyan -V, --version}    Print cies program version            {dim [boolean]}`
-    ]))
   })
 })

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -8,11 +8,6 @@ test('works without opts', t => {
   return cies().then(deps => {
     t.same(deps, [
       {
-        name: 'chalk',
-        semver: pkg.dependencies.chalk,
-        types: ['prod']
-      },
-      {
         name: 'latest-version',
         semver: pkg.dependencies['latest-version'],
         types: ['prod']
@@ -30,6 +25,11 @@ test('works without opts', t => {
       {
         name: 'sywac',
         semver: pkg.dependencies.sywac,
+        types: ['prod']
+      },
+      {
+        name: 'sywac-style-basic',
+        semver: pkg.dependencies['sywac-style-basic'],
         types: ['prod']
       }
     ])


### PR DESCRIPTION
This PR adds the following boolean options:

- `-m` or `--major` to filter deps needing major bump
- `-n` or `--minor` to filter deps needing minor bump
- `-f` or `--patch` to filter deps needing patch bump
- `-c` or `--command` to write update command for filtered deps

Combine `-c` with `-t` to print only the update command(s), and combine it with type filters (mainly `-dx`) and these new semver bump filters (`-m`, `-n`, `-f`) to tailor the update command to select dependencies.

This will now allow `cies` to be used for not only easily checking outdated dependencies but also generating appropriate commands to update those dependencies.

Somewhat unrelated, this PR also adds colors to help text via [sywac-style-basic](https://github.com/sywac/sywac-style-basic).