### PR TITLE
chore: bump tap and fix CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mockery": "^2.1.0",
     "standard": "^12.0.0",
     "standard-version": "^4.3.0",
-    "tap": "^12.0.1"
+    "tap": "^12.6.1"
   },
   "dependencies": {
     "latest-version": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "pretest": "standard",
-    "test": "tap --cov test/test*.js",
+    "test": "FORCE_COLOR=1 tap --cov test/test*.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "release": "standard-version"
   },

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -1,7 +1,5 @@
 'use strict'
 
-process.env.FORCE_COLOR = '1'
-
 const test = require('tap').test
 const cp = require('child_process')
 const path = require('path')


### PR DESCRIPTION
Builds started failing. I'm not exactly sure why, but I think it's because `chalk` was now being loaded earlier in the lifecycle of the test process (probably because I started using chalk via sywac-style-basic instead of directly), such that doing `process.env.FORCE_COLOR = '1'`in test-cli.js was now too late for it to be picked up by the chalk usage in the test process (the child cli process being tested was still using color).

To fix, I moved the env var declaration out the test code and into the `npm test` script definition itself, so that it should already be in place by the time chalk is loaded for the test process.

At least, that's my best guess.

Fixing the build allowed me to go ahead and bump `tap` version and will allow me to rely on greenkeeper again for further dependency updates.